### PR TITLE
Use IP to determine if CCPA or GDPR apply

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-plugin-react-hooks": "^4.0.8",
     "if-env": "^1.0.4",
     "jest": "^26.1.0",
+    "mockdate": "^3.0.2",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "prop-types": "^15.7.2",

--- a/src/__mocks__/localStorageMgr.js
+++ b/src/__mocks__/localStorageMgr.js
@@ -1,0 +1,25 @@
+import { isNil } from 'src/utils'
+
+let mockStorage = {}
+
+// TODO: remove
+export const __mockClear = () => {
+  mockStorage = {}
+}
+
+export default {
+  getItem: jest.fn((key) => {
+    return mockStorage[key]
+  }),
+  setItem: jest.fn((key, val) => {
+    if (!isNil(val)) {
+      mockStorage[key] = String(val)
+    }
+  }),
+  removeItem: jest.fn((key) => {
+    delete mockStorage[key]
+  }),
+  clear: () => {
+    __mockClear()
+  },
+}

--- a/src/__mocks__/localStorageMgr.js
+++ b/src/__mocks__/localStorageMgr.js
@@ -2,11 +2,6 @@ import { isNil } from 'src/utils'
 
 let mockStorage = {}
 
-// TODO: remove
-export const __mockClear = () => {
-  mockStorage = {}
-}
-
 export default {
   getItem: jest.fn((key) => {
     return mockStorage[key]
@@ -20,6 +15,6 @@ export default {
     delete mockStorage[key]
   }),
   clear: () => {
-    __mockClear()
+    mockStorage = {}
   },
 }

--- a/src/__tests__/getClientLocation.test.js
+++ b/src/__tests__/getClientLocation.test.js
@@ -50,7 +50,7 @@ const getMockMaxMindResponse = (
 })
 
 const mockGeoIP = {
-  country: jest.fn((successCallback, failureCallback) =>
+  country: jest.fn((successCallback) =>
     successCallback(getMockMaxMindResponse())
   ),
 }
@@ -61,8 +61,8 @@ beforeAll(() => {
 })
 
 afterEach(() => {
-  const { __mockClear } = require('src/localStorageMgr')
-  __mockClear()
+  const localStorageMgr = require('src/localStorageMgr').default
+  localStorageMgr.clear()
   jest.clearAllMocks()
 
   // Because client-location.js stores location in memory

--- a/src/__tests__/getClientLocation.test.js
+++ b/src/__tests__/getClientLocation.test.js
@@ -8,7 +8,7 @@ jest.mock('src/localStorageMgr')
 const mockNow = '2018-05-15T10:30:00.000'
 
 // Local storage keys.
-const STORAGE_LOCATION_COUNTRY_ISO_CODE = 'tabCMP.clientLocation.countryIsoCode'
+const STORAGE_LOCATION_COUNTRY_ISO_CODE = 'tabCMP.clientLocation.countryISOCode'
 const STORAGE_LOCATION_IS_IN_EU = 'tabCMP.clientLocation.isInEU'
 const STORAGE_LOCATION_QUERY_TIME = 'tabCMP.clientLocation.queryTime'
 
@@ -77,9 +77,9 @@ afterAll(() => {
 describe('client-location', () => {
   it('calls MaxMind when location is not in localStorage or memory', async () => {
     expect.assertions(2)
-    const { getCountry } = require('src/getClientLocation')
-    const returnedVal = await getCountry()
-    expect(returnedVal).toBe('US')
+    const getClientLocation = require('src/getClientLocation').default
+    const { countryISOCode } = await getClientLocation()
+    expect(countryISOCode).toBe('US')
     expect(mockGeoIP.country).toHaveBeenCalled()
   })
 
@@ -92,9 +92,9 @@ describe('client-location', () => {
     localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
     localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
 
-    const { getCountry } = require('src/getClientLocation')
-    const returnedVal = await getCountry()
-    expect(returnedVal).toBe('DE')
+    const getClientLocation = require('src/getClientLocation').default
+    const { countryISOCode } = await getClientLocation()
+    expect(countryISOCode).toBe('DE')
     expect(mockGeoIP.country).not.toHaveBeenCalled()
   })
 
@@ -110,9 +110,9 @@ describe('client-location', () => {
       '2018-02-10T09:00:00.000'
     ) // expired
 
-    const { getCountry } = require('src/getClientLocation')
-    const returnedVal = await getCountry()
-    expect(returnedVal).toBe('US')
+    const getClientLocation = require('src/getClientLocation').default
+    const { countryISOCode } = await getClientLocation()
+    expect(countryISOCode).toBe('US')
     expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
   })
 
@@ -128,9 +128,9 @@ describe('client-location', () => {
       '2018-04-21T09:00:00.000'
     ) // not yet expired
 
-    const { getCountry } = require('src/getClientLocation')
-    const returnedVal = await getCountry()
-    expect(returnedVal).toBe('CA')
+    const getClientLocation = require('src/getClientLocation').default
+    const { countryISOCode } = await getClientLocation()
+    expect(countryISOCode).toBe('CA')
     expect(mockGeoIP.country).not.toHaveBeenCalled()
   })
 
@@ -142,15 +142,15 @@ describe('client-location', () => {
     localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
     localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
 
-    const { getCountry } = require('src/getClientLocation')
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    await getClientLocation()
     expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
   })
 
   it('stores the location result in localStorage after calling MaxMind', async () => {
     expect.assertions(3)
-    const { getCountry } = require('src/getClientLocation')
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    await getClientLocation()
 
     // Check that localStorage has the correct values
     const localStorageMgr = require('src/localStorageMgr').default
@@ -169,8 +169,8 @@ describe('client-location', () => {
       // Mock that MaxMind says the location is Germany
       return successCallback(getMockMaxMindResponse('DE', true))
     })
-    const { getCountry } = require('src/getClientLocation')
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    await getClientLocation()
 
     // Check that localStorage has the correct values
     const localStorageMgr = require('src/localStorageMgr').default
@@ -193,28 +193,28 @@ describe('client-location', () => {
     localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
     jest.clearAllMocks()
 
-    const { getCountry } = require('src/getClientLocation')
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    await getClientLocation()
 
     expect(localStorageMgr.setItem).not.toHaveBeenCalled()
   })
 
   it('only calls MaxMind once, even with multiple simultaneous location calls', async () => {
     expect.assertions(1)
-    const { getCountry } = require('src/getClientLocation')
-    getCountry()
-    getCountry()
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    getClientLocation()
+    getClientLocation()
+    await getClientLocation()
     expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
   })
 
   it('does not call MaxMind more then once, because the location should be in memory', async () => {
     expect.assertions(2)
-    const { getCountry } = require('src/getClientLocation')
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    await getClientLocation()
     expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
     jest.clearAllMocks()
-    await getCountry()
+    await getClientLocation()
     expect(mockGeoIP.country).not.toHaveBeenCalled()
   })
 
@@ -227,32 +227,30 @@ describe('client-location', () => {
     localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
     localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
 
-    const { getCountry } = require('src/getClientLocation')
-    await getCountry()
+    const getClientLocation = require('src/getClientLocation').default
+    await getClientLocation()
     expect(localStorageMgr.getItem).toHaveBeenCalled()
     jest.clearAllMocks()
-    await getCountry()
+    await getClientLocation()
     expect(localStorageMgr.getItem).not.toHaveBeenCalled()
   })
 
   it('returns expected value for isInEuropeanUnion when it is false (via MaxMind)', async () => {
     expect.assertions(1)
-    const { isInEuropeanUnion } = require('src/getClientLocation')
-    const returnedVal = await isInEuropeanUnion()
-    expect(returnedVal).toBe(false)
+    const getClientLocation = require('src/getClientLocation').default
+    const { isInEuropeanUnion } = await getClientLocation()
+    expect(isInEuropeanUnion).toBe(false)
   })
 
   it('returns expected value for isInEuropeanUnion when it is true (via MaxMind)', async () => {
     expect.assertions(1)
-    mockGeoIP.country.mockImplementationOnce(
-      (successCallback, failureCallback) => {
-        // Mock that MaxMind says the location is Germany
-        return successCallback(getMockMaxMindResponse('DE', true))
-      }
-    )
-    const { isInEuropeanUnion } = require('src/getClientLocation')
-    const returnedVal = await isInEuropeanUnion()
-    expect(returnedVal).toBe(true)
+    mockGeoIP.country.mockImplementationOnce((successCallback) => {
+      // Mock that MaxMind says the location is Germany
+      return successCallback(getMockMaxMindResponse('DE', true))
+    })
+    const getClientLocation = require('src/getClientLocation').default
+    const { isInEuropeanUnion } = await getClientLocation()
+    expect(isInEuropeanUnion).toBe(true)
   })
 
   it('returns expected value for isInEuropeanUnion when it is false (via localStorage)', async () => {
@@ -264,9 +262,9 @@ describe('client-location', () => {
     localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'false')
     localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
 
-    const { isInEuropeanUnion } = require('src/getClientLocation')
-    const returnedVal = await isInEuropeanUnion()
-    expect(returnedVal).toBe(false)
+    const getClientLocation = require('src/getClientLocation').default
+    const { isInEuropeanUnion } = await getClientLocation()
+    expect(isInEuropeanUnion).toBe(false)
   })
 
   it('returns expected value for isInEuropeanUnion when it is true (via localStorage)', async () => {
@@ -278,12 +276,12 @@ describe('client-location', () => {
     localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
     localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
 
-    const { isInEuropeanUnion } = require('src/getClientLocation')
-    const returnedVal = await isInEuropeanUnion()
-    expect(returnedVal).toBe(true)
+    const getClientLocation = require('src/getClientLocation').default
+    const { isInEuropeanUnion } = await getClientLocation()
+    expect(isInEuropeanUnion).toBe(true)
   })
 
-  it('throws an error if MaxMind returns an error when trying to get country code', async () => {
+  it('throws an error if MaxMind returns an error when trying to get the client location', async () => {
     expect.assertions(1)
 
     // Suppress expected console error
@@ -296,28 +294,9 @@ describe('client-location', () => {
       }
     )
 
-    const { getCountry } = require('src/getClientLocation')
-    await expect(getCountry()).rejects.toThrow(
-      'Could not determine client location country'
-    )
-  })
-
-  it('throws an error if MaxMind returns an error when trying to get EU membership status', async () => {
-    expect.assertions(1)
-
-    // Suppress expected console error
-    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
-
-    // Mock a MaxMind error
-    mockGeoIP.country.mockImplementationOnce(
-      (successCallback, failureCallback) => {
-        return failureCallback({ code: 'BAD_THING_HAPPENED' })
-      }
-    )
-
-    const { isInEuropeanUnion } = require('src/getClientLocation')
-    await expect(isInEuropeanUnion()).rejects.toThrow(
-      'Could not determine client location EU membership'
+    const getClientLocation = require('src/getClientLocation').default
+    await expect(getClientLocation()).rejects.toThrow(
+      'Could not determine client location.'
     )
   })
 
@@ -337,9 +316,9 @@ describe('client-location', () => {
   //       }
   //     )
   //
-  //     const { getCountry } = require('src/getClientLocation')
+  // const getClientLocation = require('src/getClientLocation').default
   //     try {
-  //       await getCountry()
+  //       await getClientLocation()
   //     } catch (e) {}
   //     expect(logger.error).not.toHaveBeenCalled()
   //   })
@@ -360,9 +339,9 @@ describe('client-location', () => {
   //       }
   //     )
   //
-  //     const { getCountry } = require('src/getClientLocation')
+  // const getClientLocation = require('src/getClientLocation').default
   //     try {
-  //       await getCountry()
+  //       await getClientLocation()
   //     } catch (e) {}
   //     expect(logger.error).toHaveBeenCalled()
   //   })

--- a/src/__tests__/getClientLocation.test.js
+++ b/src/__tests__/getClientLocation.test.js
@@ -85,9 +85,21 @@ describe('client-location: response data', () => {
     const data = await getClientLocation()
     expect(data).toEqual({
       countryISOCode: 'DE',
+      isInUS: false,
       isInEuropeanUnion: true,
       queryTime: mockNow,
     })
+  })
+
+  it('sets isInUS to true when the countryISOCode is US', async () => {
+    expect.assertions(1)
+    mockGeoIP.country.mockImplementationOnce((successCallback) => {
+      // Mock that MaxMind says the location is Germany
+      return successCallback(getMockMaxMindResponse('US', false))
+    })
+    const getClientLocation = require('src/getClientLocation').default
+    const { isInUS } = await getClientLocation()
+    expect(isInUS).toBe(true)
   })
 
   it('returns expected value for isInEuropeanUnion when it is false (via MaxMind)', async () => {

--- a/src/__tests__/getClientLocation.test.js
+++ b/src/__tests__/getClientLocation.test.js
@@ -1,0 +1,369 @@
+/* eslint-env jest */
+
+import MockDate from 'mockdate'
+import { isNil, getCurrentISOString } from 'src/utils'
+
+jest.mock('src/localStorageMgr')
+
+const mockNow = '2018-05-15T10:30:00.000'
+
+// Local storage keys.
+const STORAGE_LOCATION_COUNTRY_ISO_CODE = 'tabCMP.clientLocation.countryIsoCode'
+const STORAGE_LOCATION_IS_IN_EU = 'tabCMP.clientLocation.isInEU'
+const STORAGE_LOCATION_QUERY_TIME = 'tabCMP.clientLocation.queryTime'
+
+const getMockMaxMindResponse = (
+  countryIsoCode = 'US',
+  isInEuropeanUnion = null,
+  continentIsoCode = 'NA'
+) => ({
+  continent: {
+    code: continentIsoCode,
+    geoname_id: 12345678,
+    names: {
+      en: 'North America',
+    },
+  },
+  country: {
+    iso_code: countryIsoCode,
+    geoname_id: 24681012,
+    names: {
+      en: 'United States',
+    },
+    ...(!isNil(isInEuropeanUnion) && {
+      is_in_european_union: isInEuropeanUnion,
+    }),
+  },
+  registered_country: {
+    iso_code: countryIsoCode,
+    geoname_id: 24681012,
+    names: {
+      en: 'United States',
+    },
+    ...(!isNil(isInEuropeanUnion) && {
+      is_in_european_union: isInEuropeanUnion,
+    }),
+  },
+  traits: {
+    ip_address: '73.xxx.xxx.x',
+  },
+})
+
+const mockGeoIP = {
+  country: jest.fn((successCallback, failureCallback) =>
+    successCallback(getMockMaxMindResponse())
+  ),
+}
+
+beforeAll(() => {
+  MockDate.set(mockNow)
+  window.geoip2 = mockGeoIP
+})
+
+afterEach(() => {
+  const { __mockClear } = require('src/localStorageMgr')
+  __mockClear()
+  jest.clearAllMocks()
+
+  // Because client-location.js stores location in memory
+  jest.resetModules()
+})
+
+afterAll(() => {
+  MockDate.reset()
+  delete window.geoip2
+})
+
+describe('client-location', () => {
+  it('calls MaxMind when location is not in localStorage or memory', async () => {
+    expect.assertions(2)
+    const { getCountry } = require('src/getClientLocation')
+    const returnedVal = await getCountry()
+    expect(returnedVal).toBe('US')
+    expect(mockGeoIP.country).toHaveBeenCalled()
+  })
+
+  it('does not call MaxMind when the location is in localStorage', async () => {
+    expect.assertions(2)
+
+    // Location exists in localStorage
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
+    localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
+
+    const { getCountry } = require('src/getClientLocation')
+    const returnedVal = await getCountry()
+    expect(returnedVal).toBe('DE')
+    expect(mockGeoIP.country).not.toHaveBeenCalled()
+  })
+
+  it('calls MaxMind when the location is in localStorage but has expired', async () => {
+    expect.assertions(2)
+
+    // Location exists in localStorage but is expired
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'CA')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'false')
+    localStorageMgr.setItem(
+      STORAGE_LOCATION_QUERY_TIME,
+      '2018-02-10T09:00:00.000'
+    ) // expired
+
+    const { getCountry } = require('src/getClientLocation')
+    const returnedVal = await getCountry()
+    expect(returnedVal).toBe('US')
+    expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call MaxMind when the location is in localStorage and has not quite expired', async () => {
+    expect.assertions(2)
+
+    // Location exists in localStorage
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'CA')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'false')
+    localStorageMgr.setItem(
+      STORAGE_LOCATION_QUERY_TIME,
+      '2018-04-21T09:00:00.000'
+    ) // not yet expired
+
+    const { getCountry } = require('src/getClientLocation')
+    const returnedVal = await getCountry()
+    expect(returnedVal).toBe('CA')
+    expect(mockGeoIP.country).not.toHaveBeenCalled()
+  })
+
+  it('calls MaxMind when the location is in localStorage but is missing some data', async () => {
+    expect.assertions(1)
+
+    // Location exists in localStorage but we're missing the "isInEuropeanUnion" key
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
+    localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
+
+    const { getCountry } = require('src/getClientLocation')
+    await getCountry()
+    expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
+  })
+
+  it('stores the location result in localStorage after calling MaxMind', async () => {
+    expect.assertions(3)
+    const { getCountry } = require('src/getClientLocation')
+    await getCountry()
+
+    // Check that localStorage has the correct values
+    const localStorageMgr = require('src/localStorageMgr').default
+    expect(localStorageMgr.getItem(STORAGE_LOCATION_COUNTRY_ISO_CODE)).toBe(
+      'US'
+    )
+    expect(localStorageMgr.getItem(STORAGE_LOCATION_IS_IN_EU)).toBe('false')
+    expect(localStorageMgr.getItem(STORAGE_LOCATION_QUERY_TIME)).toBe(
+      getCurrentISOString()
+    )
+  })
+
+  it('stores the location result in localStorage after calling MaxMind (EU country variant)', async () => {
+    expect.assertions(3)
+    mockGeoIP.country.mockImplementationOnce((successCallback) => {
+      // Mock that MaxMind says the location is Germany
+      return successCallback(getMockMaxMindResponse('DE', true))
+    })
+    const { getCountry } = require('src/getClientLocation')
+    await getCountry()
+
+    // Check that localStorage has the correct values
+    const localStorageMgr = require('src/localStorageMgr').default
+    expect(localStorageMgr.getItem(STORAGE_LOCATION_COUNTRY_ISO_CODE)).toBe(
+      'DE'
+    )
+    expect(localStorageMgr.getItem(STORAGE_LOCATION_IS_IN_EU)).toBe('true')
+    expect(localStorageMgr.getItem(STORAGE_LOCATION_QUERY_TIME)).toBe(
+      getCurrentISOString()
+    )
+  })
+
+  it('does not set localStorage when having fetched from localStorage (i.e., no call to MaxMind)', async () => {
+    expect.assertions(1)
+
+    // Location exists in localStorage
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
+    localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
+    jest.clearAllMocks()
+
+    const { getCountry } = require('src/getClientLocation')
+    await getCountry()
+
+    expect(localStorageMgr.setItem).not.toHaveBeenCalled()
+  })
+
+  it('only calls MaxMind once, even with multiple simultaneous location calls', async () => {
+    expect.assertions(1)
+    const { getCountry } = require('src/getClientLocation')
+    getCountry()
+    getCountry()
+    await getCountry()
+    expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call MaxMind more then once, because the location should be in memory', async () => {
+    expect.assertions(2)
+    const { getCountry } = require('src/getClientLocation')
+    await getCountry()
+    expect(mockGeoIP.country).toHaveBeenCalledTimes(1)
+    jest.clearAllMocks()
+    await getCountry()
+    expect(mockGeoIP.country).not.toHaveBeenCalled()
+  })
+
+  it('does not call localStorage more then once, because the location should be in memory', async () => {
+    expect.assertions(2)
+
+    // Location exists in localStorage
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
+    localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
+
+    const { getCountry } = require('src/getClientLocation')
+    await getCountry()
+    expect(localStorageMgr.getItem).toHaveBeenCalled()
+    jest.clearAllMocks()
+    await getCountry()
+    expect(localStorageMgr.getItem).not.toHaveBeenCalled()
+  })
+
+  it('returns expected value for isInEuropeanUnion when it is false (via MaxMind)', async () => {
+    expect.assertions(1)
+    const { isInEuropeanUnion } = require('src/getClientLocation')
+    const returnedVal = await isInEuropeanUnion()
+    expect(returnedVal).toBe(false)
+  })
+
+  it('returns expected value for isInEuropeanUnion when it is true (via MaxMind)', async () => {
+    expect.assertions(1)
+    mockGeoIP.country.mockImplementationOnce(
+      (successCallback, failureCallback) => {
+        // Mock that MaxMind says the location is Germany
+        return successCallback(getMockMaxMindResponse('DE', true))
+      }
+    )
+    const { isInEuropeanUnion } = require('src/getClientLocation')
+    const returnedVal = await isInEuropeanUnion()
+    expect(returnedVal).toBe(true)
+  })
+
+  it('returns expected value for isInEuropeanUnion when it is false (via localStorage)', async () => {
+    expect.assertions(1)
+
+    // Location exists in localStorage
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'false')
+    localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
+
+    const { isInEuropeanUnion } = require('src/getClientLocation')
+    const returnedVal = await isInEuropeanUnion()
+    expect(returnedVal).toBe(false)
+  })
+
+  it('returns expected value for isInEuropeanUnion when it is true (via localStorage)', async () => {
+    expect.assertions(1)
+
+    // Location exists in localStorage
+    const localStorageMgr = require('src/localStorageMgr').default
+    localStorageMgr.setItem(STORAGE_LOCATION_COUNTRY_ISO_CODE, 'DE')
+    localStorageMgr.setItem(STORAGE_LOCATION_IS_IN_EU, 'true')
+    localStorageMgr.setItem(STORAGE_LOCATION_QUERY_TIME, getCurrentISOString())
+
+    const { isInEuropeanUnion } = require('src/getClientLocation')
+    const returnedVal = await isInEuropeanUnion()
+    expect(returnedVal).toBe(true)
+  })
+
+  it('throws an error if MaxMind returns an error when trying to get country code', async () => {
+    expect.assertions(1)
+
+    // Suppress expected console error
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+
+    // Mock a MaxMind error
+    mockGeoIP.country.mockImplementationOnce(
+      (successCallback, failureCallback) => {
+        return failureCallback({ code: 'BAD_THING_HAPPENED' })
+      }
+    )
+
+    const { getCountry } = require('src/getClientLocation')
+    await expect(getCountry()).rejects.toThrow(
+      'Could not determine client location country'
+    )
+  })
+
+  it('throws an error if MaxMind returns an error when trying to get EU membership status', async () => {
+    expect.assertions(1)
+
+    // Suppress expected console error
+    jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+
+    // Mock a MaxMind error
+    mockGeoIP.country.mockImplementationOnce(
+      (successCallback, failureCallback) => {
+        return failureCallback({ code: 'BAD_THING_HAPPENED' })
+      }
+    )
+
+    const { isInEuropeanUnion } = require('src/getClientLocation')
+    await expect(isInEuropeanUnion()).rejects.toThrow(
+      'Could not determine client location EU membership'
+    )
+  })
+
+  // TODO
+  //  eslint-disable-next-line jest/no-commented-out-tests
+  //   it('does not log an error for a typical MaxMind error', async () => {
+  //     expect.assertions(1)
+  //     const logger = require('js/utils/logger').default
+  //
+  //     // Suppress expected console error
+  //     jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+  //
+  //     // Mock a MaxMind error
+  //     mockGeoIP.country.mockImplementationOnce(
+  //       (successCallback, failureCallback) => {
+  //         return failureCallback({ code: 'HTTP_TIMEOUT' })
+  //       }
+  //     )
+  //
+  //     const { getCountry } = require('src/getClientLocation')
+  //     try {
+  //       await getCountry()
+  //     } catch (e) {}
+  //     expect(logger.error).not.toHaveBeenCalled()
+  //   })
+  //
+  //  eslint-disable-next-line jest/no-commented-out-tests
+  //   it('does log an error for a problematic MaxMind error', async () => {
+  //     expect.assertions(1)
+  //
+  //     const logger = require('js/utils/logger').default
+  //
+  //     // Suppress expected console error
+  //     jest.spyOn(console, 'error').mockImplementationOnce(() => {})
+  //
+  //     // Mock a MaxMind error
+  //     mockGeoIP.country.mockImplementationOnce(
+  //       (successCallback, failureCallback) => {
+  //         return failureCallback({ code: 'OUT_OF_QUERIES' })
+  //       }
+  //     )
+  //
+  //     const { getCountry } = require('src/getClientLocation')
+  //     try {
+  //       await getCountry()
+  //     } catch (e) {}
+  //     expect(logger.error).toHaveBeenCalled()
+  //   })
+})

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -1,16 +1,25 @@
 /* eslint no-underscore-dangle:0 */
 
 import initCMP from 'src/initCMP'
+import getClientLocation from 'src/getClientLocation'
 
 jest.mock('src/initCMP')
+jest.mock('src/getClientLocation')
 jest.mock('src/qcCmpModified')
 
 beforeEach(() => {
   window.__tcfapi = jest.fn()
+  getClientLocation.mockResolvedValue({
+    countryISOCode: 'DE',
+    isInUS: false,
+    isInEuropeanUnion: true,
+    queryTime: '2018-05-15T10:30:00.000Z',
+  })
 })
 
 afterEach(() => {
   jest.clearAllMocks()
+  delete window.tabCMP
 })
 
 describe('index.js: initializeCMP', () => {
@@ -20,11 +29,63 @@ describe('index.js: initializeCMP', () => {
     expect(index.initializeCMP).toBeDefined()
   })
 
-  it('calls initCMP', () => {
+  it('calls initCMP', async () => {
     expect.assertions(1)
     const index = require('src/index')
-    index.initializeCMP()
-    expect(initCMP).toHaveBeenCalledWith()
+    await index.initializeCMP()
+    expect(initCMP).toHaveBeenCalled()
+  })
+
+  it('sets window.tabCMP.doesGDPRApply to true when the client location is in the EU', async () => {
+    expect.assertions(1)
+    getClientLocation.mockResolvedValue({
+      countryISOCode: 'DE',
+      isInUS: false,
+      isInEuropeanUnion: true,
+      queryTime: '2018-05-15T10:30:00.000Z',
+    })
+    const index = require('src/index')
+    await index.initializeCMP()
+    expect(window.tabCMP.doesGDPRApply).toBe(true)
+  })
+
+  it('sets window.tabCMP.doesGDPRApply to false when the client location is not in the EU', async () => {
+    expect.assertions(1)
+    getClientLocation.mockResolvedValue({
+      countryISOCode: 'JP',
+      isInUS: false,
+      isInEuropeanUnion: false,
+      queryTime: '2018-05-15T10:30:00.000Z',
+    })
+    const index = require('src/index')
+    await index.initializeCMP()
+    expect(window.tabCMP.doesGDPRApply).toBe(false)
+  })
+
+  it('sets window.tabCMP.doesCCPAApply to true when the client location is in the US', async () => {
+    expect.assertions(1)
+    getClientLocation.mockResolvedValue({
+      countryISOCode: 'US',
+      isInUS: true,
+      isInEuropeanUnion: false,
+      queryTime: '2018-05-15T10:30:00.000Z',
+    })
+    const index = require('src/index')
+    await index.initializeCMP()
+    expect(window.tabCMP.doesCCPAApply).toBe(true)
+  })
+
+  it('sets window.tabCMP.doesCCPAApply to false when the client location is not in the US', async () => {
+    expect.assertions(1)
+    getClientLocation.mockResolvedValue({
+      countryISOCode: 'DE',
+      isInUS: false,
+      isInEuropeanUnion: true,
+      queryTime: '2018-05-15T10:30:00.000Z',
+    })
+    const index = require('src/index')
+    await index.initializeCMP()
+    expect(window.tabCMP.doesCCPAApply).toBe(false)
   })
 })
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -87,6 +87,15 @@ describe('index.js: initializeCMP', () => {
     await index.initializeCMP()
     expect(window.tabCMP.doesCCPAApply).toBe(false)
   })
+
+  it('sets window.tabCMP.doesGDPRApply adn window.tabCMP.doesCCPAApply to false when the client location fails', async () => {
+    expect.assertions(2)
+    getClientLocation.mockRejectedValue(new Error('Uh oh.'))
+    const index = require('src/index')
+    await index.initializeCMP()
+    expect(window.tabCMP.doesGDPRApply).toBe(false)
+    expect(window.tabCMP.doesCCPAApply).toBe(false)
+  })
 })
 
 describe('index.js:', () => {

--- a/src/__tests__/localStorageMgr.test.js
+++ b/src/__tests__/localStorageMgr.test.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-console */
+import localStorageMgr from 'src/localStorageMgr'
+
+beforeEach(() => {
+  // Spy and mock all localStorage methods.
+  ;['clear', 'getItem', 'removeItem', 'setItem'].forEach((methodName) => {
+    // https://github.com/facebook/jest/issues/6798#issuecomment-440988627
+    jest
+      .spyOn(Object.getPrototypeOf(window.localStorage), methodName)
+      .mockImplementation(() => {})
+  })
+
+  // Spy and mock console.warn.
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('localStorageMgr', () => {
+  test('getItem calls localStorage.getItem', () => {
+    expect.assertions(1)
+    localStorageMgr.getItem('bar')
+    expect(window.localStorage.getItem).toHaveBeenCalledWith('bar')
+  })
+
+  test('getItem warns in console if using localStorage throws', () => {
+    expect.assertions(1)
+    const mockErr = new Error('This browser is quite private.')
+    window.localStorage.getItem.mockImplementation(() => {
+      throw mockErr
+    })
+    localStorageMgr.getItem('bar')
+    expect(console.warn).toHaveBeenCalledWith(
+      '[tab-cmp] localStorage not supported.',
+      mockErr
+    )
+  })
+
+  test('setItem calls localStorage.setItem', () => {
+    expect.assertions(1)
+    localStorageMgr.setItem('foo', 123)
+    expect(window.localStorage.setItem).toHaveBeenCalledWith('foo', 123)
+  })
+
+  test('setItem warns in console if using localStorage throws', () => {
+    expect.assertions(1)
+    const mockErr = new Error('This browser is quite private.')
+    window.localStorage.setItem.mockImplementation(() => {
+      throw mockErr
+    })
+    localStorageMgr.setItem('foo', 123)
+    expect(console.warn).toHaveBeenCalledWith(
+      '[tab-cmp] localStorage not supported.',
+      mockErr
+    )
+  })
+
+  test('removeItem calls localStorage.removeItem', () => {
+    expect.assertions(1)
+    localStorageMgr.removeItem('bar')
+    expect(window.localStorage.removeItem).toHaveBeenCalledWith('bar')
+  })
+
+  test('removeItem warns in console if using localStorage throws', () => {
+    expect.assertions(1)
+    const mockErr = new Error('This browser is quite private.')
+    window.localStorage.removeItem.mockImplementation(() => {
+      throw mockErr
+    })
+    localStorageMgr.removeItem('bar')
+    expect(console.warn).toHaveBeenCalledWith(
+      '[tab-cmp] localStorage not supported.',
+      mockErr
+    )
+  })
+})

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,0 +1,37 @@
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('utils: isNil', () => {
+  test('returns true for undefined', () => {
+    expect.assertions(1)
+    const { isNil } = require('src/utils')
+    expect(isNil()).toBe(true)
+  })
+
+  test('returns true for null', () => {
+    expect.assertions(1)
+    const { isNil } = require('src/utils')
+    expect(isNil(null)).toBe(true)
+  })
+
+  test('returns false for zero', () => {
+    expect.assertions(1)
+    const { isNil } = require('src/utils')
+    expect(isNil(0)).toBe(false)
+  })
+
+  test('returns false for an empty string', () => {
+    expect.assertions(1)
+    const { isNil } = require('src/utils')
+    expect(isNil('')).toBe(false)
+  })
+
+  test('returns false for false', () => {
+    expect.assertions(1)
+    const { isNil } = require('src/utils')
+    expect(isNil(false)).toBe(false)
+  })
+})
+
+// TODO: more tests

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -1,4 +1,13 @@
+import MockDate from 'mockdate'
+
+const mockNow = '2019-12-24T14:32:01.000Z'
+
+beforeEach(() => {
+  MockDate.set(mockNow)
+})
+
 afterEach(() => {
+  MockDate.reset()
   jest.clearAllMocks()
 })
 
@@ -31,6 +40,21 @@ describe('utils: isNil', () => {
     expect.assertions(1)
     const { isNil } = require('src/utils')
     expect(isNil(false)).toBe(false)
+  })
+})
+
+describe('utils: getCurrentISOTimestamp', () => {
+  test('returns the expected value', () => {
+    expect.assertions(1)
+    const { getCurrentISOTimestamp } = require('src/utils')
+    expect(getCurrentISOTimestamp()).toEqual('2019-12-24T14:32:01.000Z')
+  })
+
+  test('returns the expected value for another timestamp', () => {
+    expect.assertions(1)
+    MockDate.set('2020-03-10T00:00:01.000Z')
+    const { getCurrentISOTimestamp } = require('src/utils')
+    expect(getCurrentISOTimestamp()).toEqual('2020-03-10T00:00:01.000Z')
   })
 })
 

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -12,31 +12,31 @@ afterEach(() => {
 })
 
 describe('utils: isNil', () => {
-  test('returns true for undefined', () => {
+  it('returns true for undefined', () => {
     expect.assertions(1)
     const { isNil } = require('src/utils')
     expect(isNil()).toBe(true)
   })
 
-  test('returns true for null', () => {
+  it('returns true for null', () => {
     expect.assertions(1)
     const { isNil } = require('src/utils')
     expect(isNil(null)).toBe(true)
   })
 
-  test('returns false for zero', () => {
+  it('returns false for zero', () => {
     expect.assertions(1)
     const { isNil } = require('src/utils')
     expect(isNil(0)).toBe(false)
   })
 
-  test('returns false for an empty string', () => {
+  it('returns false for an empty string', () => {
     expect.assertions(1)
     const { isNil } = require('src/utils')
     expect(isNil('')).toBe(false)
   })
 
-  test('returns false for false', () => {
+  it('returns false for false', () => {
     expect.assertions(1)
     const { isNil } = require('src/utils')
     expect(isNil(false)).toBe(false)
@@ -44,13 +44,13 @@ describe('utils: isNil', () => {
 })
 
 describe('utils: getCurrentISOString', () => {
-  test('returns the expected value', () => {
+  it('returns the expected value', () => {
     expect.assertions(1)
     const { getCurrentISOString } = require('src/utils')
     expect(getCurrentISOString()).toEqual('2019-12-24T14:32:01.000Z')
   })
 
-  test('returns the expected value for another timestamp', () => {
+  it('returns the expected value for another timestamp', () => {
     expect.assertions(1)
     MockDate.set('2020-03-10T00:00:01.000Z')
     const { getCurrentISOString } = require('src/utils')
@@ -59,13 +59,61 @@ describe('utils: getCurrentISOString', () => {
 })
 
 describe('utils: ISOStringToDate', () => {
-  test('works as expected', () => {
+  it('works as expected', () => {
     expect.assertions(1)
     const { ISOStringToDate } = require('src/utils')
     const ISOString = '2019-10-31T18:02:45.421Z' // UTC ms = 1572544965421
     const expectedDate = new Date(1572544965421)
     expect(ISOStringToDate(ISOString)).toEqual(expectedDate)
   })
+
+  it('throws if no input is provided', () => {
+    expect.assertions(1)
+    const { ISOStringToDate } = require('src/utils')
+    expect(() => {
+      ISOStringToDate()
+    }).toThrow()
+  })
+
+  it('throws if a number is provided', () => {
+    expect.assertions(1)
+    const { ISOStringToDate } = require('src/utils')
+    expect(() => {
+      ISOStringToDate(1572544965421)
+    }).toThrow()
+  })
 })
 
-// TODO: more tests
+describe('utils: getNumDaysBetweenDates', () => {
+  it('works for exactly 2 days', () => {
+    expect.assertions(1)
+    const { getNumDaysBetweenDates, ISOStringToDate } = require('src/utils')
+    const firstDate = ISOStringToDate('2019-10-29T18:02:45.421Z')
+    const laterDate = ISOStringToDate('2019-10-31T18:02:45.421Z')
+    expect(getNumDaysBetweenDates(laterDate, firstDate)).toEqual(2)
+  })
+
+  it('works for 2 days and change', () => {
+    expect.assertions(1)
+    const { getNumDaysBetweenDates, ISOStringToDate } = require('src/utils')
+    const firstDate = ISOStringToDate('2019-10-29T18:02:45.421Z')
+    const laterDate = ISOStringToDate('2019-10-31T19:04:12.001Z')
+    expect(getNumDaysBetweenDates(laterDate, firstDate)).toEqual(2.04266875)
+  })
+
+  it('returns a negative value when the inputs are reversed', () => {
+    expect.assertions(1)
+    const { getNumDaysBetweenDates, ISOStringToDate } = require('src/utils')
+    const firstDate = ISOStringToDate('2019-10-29T18:02:45.421Z')
+    const laterDate = ISOStringToDate('2019-10-31T19:04:12.001Z')
+    expect(getNumDaysBetweenDates(firstDate, laterDate)).toEqual(-2.04266875)
+  })
+
+  it('works for a multi-month time diff', () => {
+    expect.assertions(1)
+    const { getNumDaysBetweenDates, ISOStringToDate } = require('src/utils')
+    const firstDate = ISOStringToDate('2019-04-29T12:02:45.421Z')
+    const laterDate = ISOStringToDate('2019-10-31T18:02:45.421Z')
+    expect(getNumDaysBetweenDates(laterDate, firstDate)).toEqual(185.25)
+  })
+})

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -43,18 +43,28 @@ describe('utils: isNil', () => {
   })
 })
 
-describe('utils: getCurrentISOTimestamp', () => {
+describe('utils: getCurrentISOString', () => {
   test('returns the expected value', () => {
     expect.assertions(1)
-    const { getCurrentISOTimestamp } = require('src/utils')
-    expect(getCurrentISOTimestamp()).toEqual('2019-12-24T14:32:01.000Z')
+    const { getCurrentISOString } = require('src/utils')
+    expect(getCurrentISOString()).toEqual('2019-12-24T14:32:01.000Z')
   })
 
   test('returns the expected value for another timestamp', () => {
     expect.assertions(1)
     MockDate.set('2020-03-10T00:00:01.000Z')
-    const { getCurrentISOTimestamp } = require('src/utils')
-    expect(getCurrentISOTimestamp()).toEqual('2020-03-10T00:00:01.000Z')
+    const { getCurrentISOString } = require('src/utils')
+    expect(getCurrentISOString()).toEqual('2020-03-10T00:00:01.000Z')
+  })
+})
+
+describe('utils: ISOStringToDate', () => {
+  test('works as expected', () => {
+    expect.assertions(1)
+    const { ISOStringToDate } = require('src/utils')
+    const ISOString = '2019-10-31T18:02:45.421Z' // UTC ms = 1572544965421
+    const expectedDate = new Date(1572544965421)
+    expect(ISOStringToDate(ISOString)).toEqual(expectedDate)
   })
 })
 

--- a/src/getClientLocation.js
+++ b/src/getClientLocation.js
@@ -160,7 +160,7 @@ const getLocationFromLocalStorage = () => {
   }
 
   // If the location data is too old, return null.
-  const now = getCurrentISOString()
+  const now = new Date()
   const daysSinceLocationQuery = getNumDaysBetweenDates(now, queryTime)
   const LOCATION_EXPIRE_DAYS = 60
   if (daysSinceLocationQuery > LOCATION_EXPIRE_DAYS) {

--- a/src/getClientLocation.js
+++ b/src/getClientLocation.js
@@ -10,9 +10,6 @@ import {
   ISOStringToDate,
 } from 'src/utils'
 
-// TODO: return ClientLocation object
-// TODO: reconfigure ClientLocation object to include CCPA
-
 // TODO
 const logger = () => {}
 
@@ -36,7 +33,7 @@ let locationFetchPromise = null
 function ClientLocation(countryISOCode, isInEuropeanUnion, queryTime) {
   this.countryISOCode = countryISOCode
   this.isInEuropeanUnion = isInEuropeanUnion
-  // this.isInUS = countryISOCode === 'US'
+  this.isInUS = countryISOCode && countryISOCode.toUpperCase() === 'US'
 
   // An ISO string
   this.queryTime = queryTime

--- a/src/getClientLocation.js
+++ b/src/getClientLocation.js
@@ -21,7 +21,7 @@ const STORAGE_PREFIX = 'tabCMP'
 const STORAGE_CLIENT_LOCATION_PREFIX = 'clientLocation'
 const makeStorageKey = (keyName) =>
   `${STORAGE_PREFIX}.${STORAGE_CLIENT_LOCATION_PREFIX}.${keyName}`
-const STORAGE_COUNTRY_ISO_CODE = makeStorageKey('countryIsoCode')
+const STORAGE_COUNTRY_ISO_CODE = makeStorageKey('countryISOCode')
 const STORAGE_IS_IN_EU = makeStorageKey('isInEU')
 const STORAGE_QUERY_TIME = makeStorageKey('queryTime')
 
@@ -33,9 +33,10 @@ let location = null
 // more than once.
 let locationFetchPromise = null
 
-function ClientLocation(countryIsoCode, isInEuropeanUnion, queryTime) {
-  this.countryIsoCode = countryIsoCode
+function ClientLocation(countryISOCode, isInEuropeanUnion, queryTime) {
+  this.countryISOCode = countryISOCode
   this.isInEuropeanUnion = isInEuropeanUnion
+  // this.isInUS = countryISOCode === 'US'
 
   // An ISO string
   this.queryTime = queryTime
@@ -178,7 +179,7 @@ const getLocationFromLocalStorage = () => {
 const setLocationInLocalStorage = (userClientLocation) => {
   localStorageMgr.setItem(
     STORAGE_COUNTRY_ISO_CODE,
-    userClientLocation.countryIsoCode
+    userClientLocation.countryISOCode
   )
   localStorageMgr.setItem(
     STORAGE_IS_IN_EU,
@@ -188,12 +189,12 @@ const setLocationInLocalStorage = (userClientLocation) => {
 }
 
 /**
- * Return client's location. Try to get the location data from memory;
+ * Return the client's location. Try to get the location data from memory;
  * fall back to localStorage; then fall back to querying MaxMind for
  * new location data. Throw an error if we cannot determine location.
  * @return {Promise<ClientLocation>} The client's location
  */
-const getLocation = async () => {
+const getClientLocation = async () => {
   // Only fetch location if we haven't already.
   if (!location) {
     // Try to get the location data from localStorage.
@@ -207,10 +208,10 @@ const getLocation = async () => {
       try {
         maxMindLocation = await getLocationFromMaxMind()
       } catch (e) {
-        throw new Error('Could not determine location.')
+        throw new Error('Could not determine client location.')
       }
       if (!maxMindLocation) {
-        throw new Error('Could not determine location.')
+        throw new Error('Could not determine client location.')
       }
 
       // Save the location to localStorage and return it.
@@ -221,31 +222,4 @@ const getLocation = async () => {
   return location
 }
 
-/**
- * Return the ISO 3166-1 country code of the country the client is in.
- * Throw an error if we could not determine the country.
- * See ISO codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
- * @return {Promise<string>} The two-character ISO 3166-1 country code
- */
-export const getCountry = async () => {
-  try {
-    const clientLocation = await getLocation()
-    return clientLocation.countryIsoCode
-  } catch (e) {
-    throw new Error('Could not determine client location country.')
-  }
-}
-
-/**
- * Return whether the client is in the European Union.
- * Throw an error if we could not determine the country.
- * @return {Promise<Boolean>} Whether or not the client is in the EU
- */
-export const isInEuropeanUnion = async () => {
-  try {
-    const clientLocation = await getLocation()
-    return clientLocation.isInEuropeanUnion
-  } catch (e) {
-    throw new Error('Could not determine client location EU membership.')
-  }
-}
+export default getClientLocation

--- a/src/getClientLocation.js
+++ b/src/getClientLocation.js
@@ -5,9 +5,9 @@
 import localStorageMgr from 'src/localStorageMgr'
 import {
   isNil,
-  getCurrentISOTimestamp,
-  getNumDaysBetweenDatetimes,
-  parseISOTimestamp,
+  getCurrentISOString,
+  getNumDaysBetweenDates,
+  ISOStringToDate,
 } from 'src/utils'
 
 // TODO: return ClientLocation object
@@ -111,7 +111,7 @@ const getLocationFromMaxMind = () => {
             new ClientLocation(
               data.country.iso_code,
               isInEuropeanUnion,
-              getCurrentISOTimestamp()
+              getCurrentISOString()
             )
           )
         },
@@ -144,22 +144,24 @@ const getLocationFromLocalStorage = () => {
   const countryCode = localStorageMgr.getItem(STORAGE_COUNTRY_ISO_CODE)
   const isInEuropeanUnionStr = localStorageMgr.getItem(STORAGE_IS_IN_EU)
   const queryTimeISO = localStorageMgr.getItem(STORAGE_QUERY_TIME)
-  const queryTime = parseISOTimestamp(queryTimeISO)
+  let queryTime
+  try {
+    queryTime = ISOStringToDate(queryTimeISO)
+  } catch (e) {
+    queryTime = null
+  }
   const isInEuropeanUnion = localStorageMgr.getItem(STORAGE_IS_IN_EU) === 'true'
 
   // If the location data does not exist, return null.
   const isDataValid =
-    !isNil(countryCode) &&
-    !isNil(isInEuropeanUnionStr) &&
-    !isNil(queryTime) &&
-    queryTime.isValid()
+    !isNil(countryCode) && !isNil(isInEuropeanUnionStr) && !isNil(queryTime) // null if the date is invalid
   if (!isDataValid) {
     return null
   }
 
   // If the location data is too old, return null.
-  const now = getCurrentISOTimestamp()
-  const daysSinceLocationQuery = getNumDaysBetweenDatetimes(now, queryTime)
+  const now = getCurrentISOString()
+  const daysSinceLocationQuery = getNumDaysBetweenDates(now, queryTime)
   const LOCATION_EXPIRE_DAYS = 60
   if (daysSinceLocationQuery > LOCATION_EXPIRE_DAYS) {
     return null

--- a/src/getClientLocation.js
+++ b/src/getClientLocation.js
@@ -1,0 +1,249 @@
+// Get the client location with a country-level granularity.
+// This expects that the MaxMind script already created the
+// `window.geoip2` object.
+
+import localStorageMgr from 'src/localStorageMgr'
+import {
+  isNil,
+  getCurrentISOTimestamp,
+  getNumDaysBetweenDatetimes,
+  parseISOTimestamp,
+} from 'src/utils'
+
+// TODO: return ClientLocation object
+// TODO: reconfigure ClientLocation object to include CCPA
+
+// TODO
+const logger = () => {}
+
+// Local storage keys.
+const STORAGE_PREFIX = 'tabCMP'
+const STORAGE_CLIENT_LOCATION_PREFIX = 'clientLocation'
+const makeStorageKey = (keyName) =>
+  `${STORAGE_PREFIX}.${STORAGE_CLIENT_LOCATION_PREFIX}.${keyName}`
+const STORAGE_COUNTRY_ISO_CODE = makeStorageKey('countryIsoCode')
+const STORAGE_IS_IN_EU = makeStorageKey('isInEU')
+const STORAGE_QUERY_TIME = makeStorageKey('queryTime')
+
+// Store location in memory to avoid unnecessary queries.
+// This will be an instance of ClientLocation.
+let location = null
+
+// To store in-progress fetches so we don't fetch location
+// more than once.
+let locationFetchPromise = null
+
+function ClientLocation(countryIsoCode, isInEuropeanUnion, queryTime) {
+  this.countryIsoCode = countryIsoCode
+  this.isInEuropeanUnion = isInEuropeanUnion
+
+  // An ISO string
+  this.queryTime = queryTime
+}
+
+/**
+ * Whether a MaxMind error concerns us enough to log.
+ * @param {Object} err - The MaxMind error object
+ * @return {Boolean} Whether we should log the MaxMind error
+ */
+const shouldLogMaxMindError = (err) => {
+  return (
+    ['QUERY_FORBIDDEN', 'OUT_OF_QUERIES', 'PERMISSION_REQUIRED'].indexOf(
+      err.code
+    ) > -1
+  )
+}
+
+/**
+ * Call MaxMind for location data and return a ClientLocation object.
+ * @return {ClientLocation} The location object
+ */
+const getLocationFromMaxMind = () => {
+  // MaxMind response structure. See:
+  // https://dev.maxmind.com/geoip/geoip2/web-services/
+  // The key "country.is_in_european_union" will be true if the country
+  // is in EU. Otherwise, it will be undefined.
+  // {
+  //   "continent": {
+  //     "code": "NA",
+  //     "geoname_id": 6255149,
+  //     "names": {
+  //       "en": "North America"
+  //       ...
+  //     }
+  //   },
+  //   "country": {
+  //     "iso_code": "US",
+  //     "geoname_id": 6252001,
+  //     "names": {
+  //       "en": "United States",
+  //       ...
+  //     }
+  //   },
+  //   "registered_country": {
+  //     "iso_code": "US",
+  //     "geoname_id": 6252001,
+  //     "names": {
+  //       "en": "United States",
+  //       ...
+  //     }
+  //   },
+  //   "traits": {
+  //     "ip_address": "73.xxx.xxx.x"
+  //   }
+  // }
+
+  // If a fetch is in progress, return that promise
+  // so we don't fetch location more than once.
+  if (locationFetchPromise) {
+    return locationFetchPromise
+  }
+
+  // Store the promise so subsequent requests can use it
+  // if this request is still in progress.
+  locationFetchPromise = new Promise((resolve, reject) => {
+    // https://dev.maxmind.com/geoip/geoip2/javascript/
+    try {
+      window.geoip2.country(
+        (data) => {
+          const isInEuropeanUnion = data.country.is_in_european_union === true
+          resolve(
+            new ClientLocation(
+              data.country.iso_code,
+              isInEuropeanUnion,
+              getCurrentISOTimestamp()
+            )
+          )
+        },
+        (err) => {
+          // Log a subset of errors that we care about to Sentry.
+          if (shouldLogMaxMindError(err)) {
+            logger.error(err)
+          }
+          reject(err)
+        }
+      )
+    } catch (err) {
+      // Log a subset of errors that we care about to Sentry.
+      if (shouldLogMaxMindError(err)) {
+        logger.error(err)
+      }
+      reject(err)
+    }
+  })
+  return locationFetchPromise
+}
+
+/**
+ * Try to get location data from localStorage. If it exists and hasn't
+ * expired, return a ClientLocation object; else return null.
+ * @return {ClientLocation|null} The location object, or null if no
+ *   unexpired location exists in localStorage.
+ */
+const getLocationFromLocalStorage = () => {
+  const countryCode = localStorageMgr.getItem(STORAGE_COUNTRY_ISO_CODE)
+  const isInEuropeanUnionStr = localStorageMgr.getItem(STORAGE_IS_IN_EU)
+  const queryTimeISO = localStorageMgr.getItem(STORAGE_QUERY_TIME)
+  const queryTime = parseISOTimestamp(queryTimeISO)
+  const isInEuropeanUnion = localStorageMgr.getItem(STORAGE_IS_IN_EU) === 'true'
+
+  // If the location data does not exist, return null.
+  const isDataValid =
+    !isNil(countryCode) &&
+    !isNil(isInEuropeanUnionStr) &&
+    !isNil(queryTime) &&
+    queryTime.isValid()
+  if (!isDataValid) {
+    return null
+  }
+
+  // If the location data is too old, return null.
+  const now = getCurrentISOTimestamp()
+  const daysSinceLocationQuery = getNumDaysBetweenDatetimes(now, queryTime)
+  const LOCATION_EXPIRE_DAYS = 60
+  if (daysSinceLocationQuery > LOCATION_EXPIRE_DAYS) {
+    return null
+  }
+
+  return new ClientLocation(countryCode, isInEuropeanUnion, queryTime)
+}
+
+/**
+ * Store the location data in localStorage.
+ * @param {ClientLocation} location - The ClientLocation object
+ * @return {undefined}
+ */
+const setLocationInLocalStorage = (userClientLocation) => {
+  localStorageMgr.setItem(
+    STORAGE_COUNTRY_ISO_CODE,
+    userClientLocation.countryIsoCode
+  )
+  localStorageMgr.setItem(
+    STORAGE_IS_IN_EU,
+    userClientLocation.isInEuropeanUnion.toString()
+  )
+  localStorageMgr.setItem(STORAGE_QUERY_TIME, userClientLocation.queryTime)
+}
+
+/**
+ * Return client's location. Try to get the location data from memory;
+ * fall back to localStorage; then fall back to querying MaxMind for
+ * new location data. Throw an error if we cannot determine location.
+ * @return {Promise<ClientLocation>} The client's location
+ */
+const getLocation = async () => {
+  // Only fetch location if we haven't already.
+  if (!location) {
+    // Try to get the location data from localStorage.
+    const locationLocalStorage = getLocationFromLocalStorage()
+    if (locationLocalStorage) {
+      location = locationLocalStorage
+      // If location isn't in localStorage, query for it.
+    } else {
+      // Throw an error if MaxMind cannot determine the location.
+      let maxMindLocation = null
+      try {
+        maxMindLocation = await getLocationFromMaxMind()
+      } catch (e) {
+        throw new Error('Could not determine location.')
+      }
+      if (!maxMindLocation) {
+        throw new Error('Could not determine location.')
+      }
+
+      // Save the location to localStorage and return it.
+      location = maxMindLocation
+      setLocationInLocalStorage(location)
+    }
+  }
+  return location
+}
+
+/**
+ * Return the ISO 3166-1 country code of the country the client is in.
+ * Throw an error if we could not determine the country.
+ * See ISO codes: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+ * @return {Promise<string>} The two-character ISO 3166-1 country code
+ */
+export const getCountry = async () => {
+  try {
+    const clientLocation = await getLocation()
+    return clientLocation.countryIsoCode
+  } catch (e) {
+    throw new Error('Could not determine client location country.')
+  }
+}
+
+/**
+ * Return whether the client is in the European Union.
+ * Throw an error if we could not determine the country.
+ * @return {Promise<Boolean>} Whether or not the client is in the EU
+ */
+export const isInEuropeanUnion = async () => {
+  try {
+    const clientLocation = await getLocation()
+    return clientLocation.isInEuropeanUnion
+  } catch (e) {
+    throw new Error('Could not determine client location EU membership.')
+  }
+}

--- a/src/getClientLocation.js
+++ b/src/getClientLocation.js
@@ -205,7 +205,9 @@ const getClientLocation = async () => {
       try {
         maxMindLocation = await getLocationFromMaxMind()
       } catch (e) {
-        throw new Error('Could not determine client location.')
+        throw new Error(
+          `Could not determine client location. Error: ${JSON.stringify(e)}`
+        )
       }
       if (!maxMindLocation) {
         throw new Error('Could not determine client location.')

--- a/src/index.js
+++ b/src/index.js
@@ -15,8 +15,14 @@ export const initializeCMP = async (options) => {
     `[tab-cmp] Called initializeCMP with options: ${JSON.stringify(options)}`
   )
 
-  // TODO: handle potential failure to fetch location
-  const { isInUS, isInEuropeanUnion } = await getClientLocation()
+  let isInUS = false
+  let isInEuropeanUnion = false
+  try {
+    ;({ isInUS, isInEuropeanUnion } = await getClientLocation())
+    // If client location determination fails, default to no GDPR/CCPA,
+    // which will fall back on IP geolocation in calls to ad partners.
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
 
   // eslint-disable-next-line no-console
   console.log(

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,28 @@
 import initCMP from 'src/initCMP'
+import getClientLocation from 'src/getClientLocation'
+
+// TODO: gracefully handle if this code is run on the
+// server side.
 
 export const getCMPHeadScript = () => {
   // eslint-disable-next-line no-console
   console.log(`[tab-cmp] TODO: getCMPHeadScript`)
 }
 
-export const initializeCMP = (options) => {
+export const initializeCMP = async (options) => {
   // eslint-disable-next-line no-console
   console.log(
     `[tab-cmp] Called initializeCMP with options: ${JSON.stringify(options)}`
   )
 
-  // TODO: use geoip service
-  const isUserInEU = false
-  const isUserInUS = true
+  // TODO: handle potential failure to fetch location
+  const { isInUS, isInEuropeanUnion } = await getClientLocation()
 
-  // TODO: move to separate module
+  // eslint-disable-next-line no-console
+  console.log(
+    `[tab-cmp] Client location. isInEU: ${isInEuropeanUnion}. isInUS: ${isInUS}`
+  )
+
   // TODO: add to head tag
   window.tabCMP = window.tabCMP || {}
 
@@ -26,13 +33,13 @@ export const initializeCMP = (options) => {
     'doesGDPRApply'
   )
     ? window.tabCMP.doesGDPRApply
-    : isUserInEU
+    : isInEuropeanUnion
   window.tabCMP.doesCCPAApply = Object.prototype.hasOwnProperty.call(
     window.tabCMP,
     'doesCCPAApply'
   )
     ? window.tabCMP.doesCCPAApply
-    : isUserInUS
+    : isInUS
 
   initCMP()
 

--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ export const initializeCMP = async (options) => {
     `[tab-cmp] Client location. isInEU: ${isInEuropeanUnion}. isInUS: ${isInUS}`
   )
 
-  // TODO: add to head tag
   window.tabCMP = window.tabCMP || {}
 
   // Only set doesGDPRApply and doesCCPAApply if they're not

--- a/src/localStorageMgr.js
+++ b/src/localStorageMgr.js
@@ -1,0 +1,32 @@
+const localStorageMgr = {}
+
+localStorageMgr.setItem = (key, value) => {
+  try {
+    window.localStorage.setItem(key, value)
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('[tab-cmp] localStorage not supported.', e)
+  }
+}
+
+localStorageMgr.getItem = (key) => {
+  try {
+    const value = window.localStorage.getItem(key)
+    return value
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('[tab-cmp] localStorage not supported.', e)
+    return null
+  }
+}
+
+localStorageMgr.removeItem = (key) => {
+  try {
+    window.localStorage.removeItem(key)
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.warn('[tab-cmp] localStorage not supported.', e)
+  }
+}
+
+export default localStorageMgr

--- a/src/tagModified.html
+++ b/src/tagModified.html
@@ -3,6 +3,9 @@
 <!-- Quantcast Choice. Consent Manager Tag v2.0 (for TCF 2.0) -->
 <script type="text/javascript" async=true>
 (function() {
+  // Gladly modified: create window object.
+  window.tabCMP = window.tabCMP || {}
+
   // Gladly modified: don't load the QC Choice script.
   // We'll import it ourselves.
   // var host = window.location.hostname;

--- a/src/tagModified.html
+++ b/src/tagModified.html
@@ -1,3 +1,5 @@
+<!-- MaxMind for determining user country location. -->
+<script src="//geoip-js.com/js/apis/geoip2/v2.1/geoip2.js" type="text/javascript"></script>
 <!-- Quantcast Choice. Consent Manager Tag v2.0 (for TCF 2.0) -->
 <script type="text/javascript" async=true>
 (function() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,11 +2,17 @@ export const isNil = (value) => {
   return value == null
 }
 
-export const getCurrentISOTimestamp = () => new Date().toISOString()
+export const getCurrentISOString = () => new Date().toISOString()
 
-export const parseISOTimestamp = (timestamp) => Date.parse(timestamp)
+export const ISOStringToDate = (ISOString) => {
+  const utcMs = Date.parse(ISOString)
+  if (Number.isNaN(utcMs)) {
+    throw new Error('Invalid string passed to ISOStringToDate.')
+  }
+  return new Date(utcMs)
+}
 
-export const getNumDaysBetweenDatetimes = (dateA, dateB) => {
+export const getNumDaysBetweenDates = (dateA, dateB) => {
   const msInDay = 1000 * 60 * 60 * 24
   return (dateA - dateB) / msInDay
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,7 +6,7 @@ export const getCurrentISOTimestamp = () => new Date().toISOString()
 
 export const parseISOTimestamp = (timestamp) => Date.parse(timestamp)
 
-export const getNumDaysBetweenDates = (dateA, dateB) => {
+export const getNumDaysBetweenDatetimes = (dateA, dateB) => {
   const msInDay = 1000 * 60 * 60 * 24
   return (dateA - dateB) / msInDay
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,12 @@
+export const isNil = (value) => {
+  return value == null
+}
+
+export const getCurrentISOTimestamp = () => new Date().toISOString()
+
+export const parseISOTimestamp = (timestamp) => Date.parse(timestamp)
+
+export const getNumDaysBetweenDates = (dateA, dateB) => {
+  const msInDay = 1000 * 60 * 60 * 24
+  return (dateA - dateB) / msInDay
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3931,6 +3931,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
* Add MaxMind for country-level geolocation, including a script in the head tag
* Add a client location module
* Add a localStorage wrapper
* Use the client location to set the `tabCMP` window variable fields, which our modified CMP code relies on to determine location

Still to do: handle error logging from the client location module.