### PR TITLE
Add ability to enable debugging via URL param

### DIFF
--- a/src/__mocks__/utils.js
+++ b/src/__mocks__/utils.js
@@ -1,0 +1,5 @@
+const mock = jest.genMockFromModule('src/utils')
+
+mock.getURL = jest.fn(() => 'https://example.com/foo/bar/')
+
+module.exports = mock

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -6,6 +6,7 @@ jest.mock('src/qcCmpModified')
 jest.mock('src/setDefaultUSPData')
 jest.mock('src/logger')
 jest.mock('src/isClientSide')
+jest.mock('src/utils')
 
 beforeEach(() => {
   window.__tcfapi = jest.fn()
@@ -19,6 +20,8 @@ beforeEach(() => {
   })
   const isClientSide = require('src/isClientSide').default
   isClientSide.mockReturnValue(true)
+  const { getURL } = require('src/utils')
+  getURL.mockReturnValue('https://example.com/foo/bar/')
 })
 
 afterEach(() => {
@@ -227,6 +230,38 @@ describe('index.js: initializeCMP', () => {
       primaryButtonColor: '#9d4ba3',
       publisherName: 'My Site',
       publisherLogo: undefined,
+    })
+  })
+
+  it('sets debug === true when the URL param tabCMPDebug is true', async () => {
+    expect.assertions(1)
+    const { getURL } = require('src/utils')
+    getURL.mockReturnValue(
+      'https://example.com/foo/bar?abc=123&tabCMPDebug=true'
+    )
+    const index = require('src/index')
+    await index.initializeCMP({
+      debug: false,
+    })
+    const initCMP = require('src/initCMP').default
+    expect(initCMP.mock.calls[0][0]).toMatchObject({
+      debug: true,
+    })
+  })
+
+  it('does not set debug === true when the URL param tabCMPDebug is false', async () => {
+    expect.assertions(1)
+    const { getURL } = require('src/utils')
+    getURL.mockReturnValue(
+      'https://example.com/foo/bar?abc=123&tabCMPDebug=false'
+    )
+    const index = require('src/index')
+    await index.initializeCMP({
+      debug: false,
+    })
+    const initCMP = require('src/initCMP').default
+    expect(initCMP.mock.calls[0][0]).toMatchObject({
+      debug: false,
     })
   })
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -156,7 +156,8 @@ describe('index.js: initializeCMP', () => {
     await index.initializeCMP(opts)
     const { logDebugging } = require('src/logger')
     expect(logDebugging).toHaveBeenCalledWith(
-      `Called initializeCMP with options: ${JSON.stringify(opts)}`
+      `Called initializeCMP with options:`,
+      opts
     )
   })
 

--- a/src/__tests__/initCMP.test.js
+++ b/src/__tests__/initCMP.test.js
@@ -31,16 +31,6 @@ describe('initCMP', () => {
     expect(initCMP).toBeDefined()
   })
 
-  it('calls logDebugging', () => {
-    expect.assertions(1)
-    const initCMP = require('src/initCMP').default
-    const opts = getMockOptions()
-    initCMP(opts)
-    expect(logDebugging).toHaveBeenCalledWith(
-      `Called initCMP with options: ${JSON.stringify(opts)}`
-    )
-  })
-
   it('calls setUpQuantcastChoice', () => {
     expect.assertions(1)
     const initCMP = require('src/initCMP').default

--- a/src/__tests__/initCMP.test.js
+++ b/src/__tests__/initCMP.test.js
@@ -1,7 +1,6 @@
 /* eslint no-underscore-dangle:0 */
 
 import { setUpQuantcastChoice } from 'src/qcChoiceModified'
-import { logDebugging } from 'src/logger'
 
 jest.mock('src/logger')
 jest.mock('src/qcChoiceModified')

--- a/src/__tests__/logger.test.js
+++ b/src/__tests__/logger.test.js
@@ -22,6 +22,11 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
+const prefix = [
+  '%ctab-cmp',
+  'background: #7c7c7c; color: #fff; border-radius: 2px; padding: 2px 6px',
+]
+
 describe('logger: setUpLogger', () => {
   it('does not throw', () => {
     expect.assertions(1)
@@ -45,10 +50,7 @@ describe('logger: logDebugging', () => {
       debug: true,
     })
     logDebugging('something here')
-    expect(console.log).toHaveBeenCalledWith(
-      '[tab-cmp] [debug]:',
-      'something here'
-    )
+    expect(console.log).toHaveBeenCalledWith(...prefix, 'something here')
   })
 
   it('does not log to console when debug is not enabled', () => {
@@ -73,7 +75,7 @@ describe('logger: logDebugging', () => {
     })
     logDebugging('something here', { a: 123 }, 'more info here')
     expect(console.log).toHaveBeenCalledWith(
-      '[tab-cmp] [debug]:',
+      ...prefix,
       'something here',
       { a: 123 },
       'more info here'
@@ -105,7 +107,7 @@ describe('logger: logError', () => {
     })
     const mockErr = new Error('Uh oh!')
     logError(mockErr)
-    expect(mockConsoleError).toHaveBeenCalledWith(mockErr)
+    expect(mockConsoleError).toHaveBeenCalledWith(...prefix, mockErr)
   })
 
   it('calls the onError callback when logError is called', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -79,9 +79,7 @@ export const initializeCMP = requireClientSide(async (userOptions = {}) => {
   }
 
   try {
-    logDebugging(
-      `Called initializeCMP with options: ${JSON.stringify(options)}`
-    )
+    logDebugging(`Called initializeCMP with options:`, options)
 
     // Determine the client location to know which privacy laws apply.
     let isInUS = false

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import { logDebugging, logError, setUpLogger } from 'src/logger'
 import getClientLocation from 'src/getClientLocation'
 import setDefaultUSPData from 'src/setDefaultUSPData'
 import isClientSide from 'src/isClientSide'
+import { getURL } from 'src/utils'
 
 let tabCMPInitialized = false
 
@@ -48,6 +49,20 @@ const catchAndLogErrors = (func) => async (args) => {
 const commonWrapper = (func) =>
   requireClientSide(requireCMPInitialized(catchAndLogErrors(func)))
 
+const isDebugParamSet = () => {
+  let isDebug = false
+  try {
+    const urlStr = getURL()
+    const url = new URL(urlStr)
+    const tabCMPDebug = url.searchParams.get('tabCMPDebug')
+    isDebug = tabCMPDebug === 'true'
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(e)
+  }
+  return isDebug
+}
+
 export const initializeCMP = requireClientSide(async (userOptions = {}) => {
   // Ensure initializeCMP is called only once.
   if (tabCMPInitialized) {
@@ -60,7 +75,6 @@ export const initializeCMP = requireClientSide(async (userOptions = {}) => {
   tabCMPInitialized = true
 
   const options = {
-    debug: false,
     displayPersistentConsentLink: false,
     onError: () => {},
     primaryButtonColor: '#9d4ba3',
@@ -68,6 +82,7 @@ export const initializeCMP = requireClientSide(async (userOptions = {}) => {
     publisherLogo:
       'https://tab.gladly.io/static/logo-with-text-257bbffc6dcac5076e8ac31eed8ff73c.svg',
     ...userOptions,
+    debug: isDebugParamSet() ? true : userOptions.debug || false,
   }
 
   try {

--- a/src/initCMP.js
+++ b/src/initCMP.js
@@ -5,7 +5,6 @@ import { setUpQuantcastChoice, getLanguage } from 'src/qcChoiceModified'
 import { logDebugging } from 'src/logger'
 
 const initCMP = (options) => {
-  logDebugging(`Called initCMP with options: ${JSON.stringify(options)}`)
   const {
     publisherName,
     publisherLogo,

--- a/src/initCMP.js
+++ b/src/initCMP.js
@@ -2,7 +2,6 @@
 /* eslint no-underscore-dangle:0 */
 
 import { setUpQuantcastChoice, getLanguage } from 'src/qcChoiceModified'
-import { logDebugging } from 'src/logger'
 
 const initCMP = (options) => {
   const {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,11 @@
 let debugEnabled = false
 let onErrorCallbackFn = () => {}
 
+const prefix = [
+  '%ctab-cmp',
+  'background: #7c7c7c; color: #fff; border-radius: 2px; padding: 2px 6px',
+]
+
 export const setUpLogger = ({ debug, onErrorCallback }) => {
   debugEnabled = debug
   if (typeof onErrorCallback === 'function') {
@@ -11,12 +16,12 @@ export const setUpLogger = ({ debug, onErrorCallback }) => {
 export const logDebugging = (...args) => {
   if (debugEnabled) {
     // eslint-disable-next-line no-console
-    console.log.apply(this, [`[tab-cmp] [debug]:`, ...args])
+    console.log.apply(this, [...prefix, ...args])
   }
 }
 
 export const logError = (err) => {
   // eslint-disable-next-line no-console
-  console.error(err)
+  console.error(...prefix, err)
   onErrorCallbackFn(err)
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,3 +16,5 @@ export const getNumDaysBetweenDates = (dateA, dateB) => {
   const msInDay = 1000 * 60 * 60 * 24
   return (dateA - dateB) / msInDay
 }
+
+export const getURL = () => window.location.href


### PR DESCRIPTION
Set URL param `tabCMPDebug=true` on a page to enable debugging.