### PR TITLE
Modify the USP ping stub

### DIFF
--- a/src/__tests__/awaitCMPLoad.test.js
+++ b/src/__tests__/awaitCMPLoad.test.js
@@ -1,5 +1,5 @@
-// import { logDebugging } from 'src/logger'
-import { getMockTabCMPGlobal } from 'src/test-utils'
+import { logDebugging } from 'src/logger'
+import { getMockTabCMPGlobal, runAsyncTimerLoops } from 'src/test-utils'
 import awaitCMPLoad from 'src/awaitCMPLoad'
 
 jest.mock('src/logger')
@@ -21,7 +21,6 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-// TODO: more tests
 describe('awaitCMPLoad', () => {
   it('resolves when the USP stub function is replaced', () => {
     expect.assertions(0)
@@ -44,5 +43,67 @@ describe('awaitCMPLoad', () => {
           throw e
         })
     })
+  })
+
+  it('rejects when the USP stub function is never replaced (it times out)', async () => {
+    expect.assertions(1)
+    const promise = awaitCMPLoad()
+      .then(() => {})
+      .catch((e) => {
+        expect(e).toEqual(new Error('Timed out while waiting for the CMP.'))
+      })
+
+    // Run out our timer that's used in polling the stub.
+    await runAsyncTimerLoops(40)
+
+    return promise
+  })
+
+  it('calls logDebugging as expected when the CMP responds successfully', async () => {
+    expect.assertions(2)
+    const promise = awaitCMPLoad()
+      .then(() => {
+        expect(logDebugging).toHaveBeenCalledWith(
+          `Polling for CMP to have loaded in updateStoredPrivacyData.`
+        )
+        expect(logDebugging).toHaveBeenCalledWith(
+          `Polling for CMP loaded. Loaded? true`
+        )
+      })
+      .catch((e) => {
+        throw e
+      })
+
+    // Mock that the CMP replaces the stub function.
+    window.__uspapi = () => {
+      // some new function
+    }
+
+    // Run out our timer that's used in polling the stub.
+    await runAsyncTimerLoops(40)
+
+    return promise
+  })
+
+  it('calls logDebugging as expected when the CMP fails to respond', async () => {
+    expect.assertions(3)
+    const promise = awaitCMPLoad()
+      .then(() => {})
+      .catch(() => {
+        expect(logDebugging).toHaveBeenCalledWith(
+          `Polling for CMP to have loaded in updateStoredPrivacyData.`
+        )
+        expect(logDebugging).toHaveBeenCalledWith(
+          `Polling for CMP loaded. Loaded? false`
+        )
+        expect(logDebugging).toHaveBeenCalledWith(
+          `Polling for CMP has timed out.`
+        )
+      })
+
+    // Run out our timer that's used in polling the stub.
+    await runAsyncTimerLoops(40)
+
+    return promise
   })
 })

--- a/src/__tests__/awaitCMPLoad.test.js
+++ b/src/__tests__/awaitCMPLoad.test.js
@@ -1,0 +1,48 @@
+// import { logDebugging } from 'src/logger'
+import { getMockTabCMPGlobal } from 'src/test-utils'
+import awaitCMPLoad from 'src/awaitCMPLoad'
+
+jest.mock('src/logger')
+
+beforeAll(() => {
+  jest.useFakeTimers()
+})
+
+beforeEach(() => {
+  window.__tcfapi = jest.fn()
+  window.__uspapi = jest.fn()
+  window.tabCMP = {
+    ...getMockTabCMPGlobal(),
+    uspStubFunction: window.__uspapi,
+  }
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+// TODO: more tests
+describe('awaitCMPLoad', () => {
+  it('resolves when the USP stub function is replaced', () => {
+    expect.assertions(0)
+    const promise = awaitCMPLoad()
+
+    // Mock that the CMP replaces the stub function.
+    window.__uspapi = () => {
+      // some new function
+    }
+
+    // Run our timer that's used in polling the stub.
+    jest.runAllTimers()
+
+    return new Promise((done) => {
+      promise
+        .then(() => {
+          done()
+        })
+        .catch((e) => {
+          throw e
+        })
+    })
+  })
+})

--- a/src/__tests__/updateStoredPrivacyData.test.js
+++ b/src/__tests__/updateStoredPrivacyData.test.js
@@ -1,17 +1,22 @@
 import { logDebugging, logError } from 'src/logger'
 import localStorageMgr from 'src/localStorageMgr'
 import {
+  getMockTabCMPGlobal,
   getMockUSPDataInUS,
   getMockUSPDataNonUS,
   getMockUSPPingResponse,
   getMockTCFDataInEU,
   getMockTCFDataNonEU,
 } from 'src/test-utils'
+import awaitCMPLoad from 'src/awaitCMPLoad'
 
 jest.mock('src/logger')
 jest.mock('src/localStorageMgr')
+jest.mock('src/awaitCMPLoad')
 
 beforeEach(() => {
+  awaitCMPLoad.mockResolvedValue()
+  window.tabCMP = getMockTabCMPGlobal()
   window.__tcfapi = jest.fn()
   window.__uspapi = jest.fn()
 })
@@ -21,22 +26,22 @@ afterEach(() => {
 })
 
 describe('updateStoredPrivacyData: TCF', () => {
-  it('does not throw if window.__tcfapi is undefined', () => {
+  it('does not throw if window.__tcfapi is undefined', async () => {
     expect.assertions(1)
     delete window.__tcfapi
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    expect(() => {
-      updateStoredPrivacyData()
+    await expect(async () => {
+      await updateStoredPrivacyData()
     }).not.toThrow()
   })
 
-  it('logs an error if window.__tcfapi is undefined', () => {
+  it('logs an error if window.__tcfapi is undefined', async () => {
     expect.assertions(1)
     delete window.__tcfapi
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logError).toHaveBeenCalledWith(
       new Error(
         '[tab-cmp] Could not update TCF local storage data. window.__tcfapi is not defined.'
@@ -44,7 +49,7 @@ describe('updateStoredPrivacyData: TCF', () => {
     )
   })
 
-  it('sets the TCF local storage value when in the EU', () => {
+  it('sets the TCF local storage value when in the EU', async () => {
     expect.assertions(1)
     const mockTCFData = getMockTCFDataInEU() // EU
     window.__tcfapi.mockImplementation((cmd, version, callback) => {
@@ -58,14 +63,14 @@ describe('updateStoredPrivacyData: TCF', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(localStorageMgr.setItem).toHaveBeenCalledWith(
       'tabCMP.tcfv2.data',
       JSON.stringify(mockTCFData)
     )
   })
 
-  it('sets the TCF local storage value when not in the EU', () => {
+  it('sets the TCF local storage value when not in the EU', async () => {
     expect.assertions(1)
     const mockTCFData = getMockTCFDataNonEU() // non-EU
     window.__tcfapi.mockImplementation((cmd, version, callback) => {
@@ -79,14 +84,14 @@ describe('updateStoredPrivacyData: TCF', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(localStorageMgr.setItem).toHaveBeenCalledWith(
       'tabCMP.tcfv2.data',
       JSON.stringify(mockTCFData)
     )
   })
 
-  it('calls logDebugging after updating local storage TCF data', () => {
+  it('calls logDebugging after updating local storage TCF data', async () => {
     expect.assertions(1)
     const mockTCFData = getMockTCFDataInEU()
     window.__tcfapi.mockImplementation((cmd, version, callback) => {
@@ -100,14 +105,14 @@ describe('updateStoredPrivacyData: TCF', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logDebugging).toHaveBeenCalledWith(
       `Successfully updated TCF local storage data. Value:`,
       mockTCFData
     )
   })
 
-  it('calls logDebugging when failing to update local storage TCF data', () => {
+  it('calls logDebugging when failing to update local storage TCF data', async () => {
     expect.assertions(1)
     const mockTCFData = getMockTCFDataInEU()
     window.__tcfapi.mockImplementation((cmd, version, callback) => {
@@ -121,7 +126,7 @@ describe('updateStoredPrivacyData: TCF', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logDebugging).toHaveBeenCalledWith(
       'Could not update TCF local storage data. The CMP errored and provided these data:',
       mockTCFData
@@ -130,22 +135,22 @@ describe('updateStoredPrivacyData: TCF', () => {
 })
 
 describe('updateStoredPrivacyData: USP', () => {
-  it('does not throw if window.__uspapi is undefined', () => {
+  it('does not throw if window.__uspapi is undefined', async () => {
     expect.assertions(1)
     delete window.__uspapi
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    expect(() => {
-      updateStoredPrivacyData()
+    await expect(async () => {
+      await updateStoredPrivacyData()
     }).not.toThrow()
   })
 
-  it('logs an error if window.__uspapi is undefined', () => {
+  it('logs an error if window.__uspapi is undefined', async () => {
     expect.assertions(1)
     delete window.__uspapi
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logError).toHaveBeenCalledWith(
       new Error(
         '[tab-cmp] Could not update USP local storage data. window.__uspapi is not defined.'
@@ -153,7 +158,7 @@ describe('updateStoredPrivacyData: USP', () => {
     )
   })
 
-  it('sets the USP local storage value when in the US', () => {
+  it('sets the USP local storage value when in the US', async () => {
     expect.assertions(1)
     const mockPingResponse = {
       ...getMockUSPPingResponse(),
@@ -175,14 +180,14 @@ describe('updateStoredPrivacyData: USP', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(localStorageMgr.setItem).toHaveBeenCalledWith(
       'tabCMP.usp.data',
       JSON.stringify(mockUSPData)
     )
   })
 
-  it('sets the USP local storage value when not in the US', () => {
+  it('sets the USP local storage value when not in the US', async () => {
     expect.assertions(1)
     const mockPingResponse = {
       ...getMockUSPPingResponse(),
@@ -204,14 +209,14 @@ describe('updateStoredPrivacyData: USP', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(localStorageMgr.setItem).toHaveBeenCalledWith(
       'tabCMP.usp.data',
       JSON.stringify(mockUSPData)
     )
   })
 
-  it('calls logDebugging after updating local storage USP data', () => {
+  it('calls logDebugging after updating local storage USP data', async () => {
     expect.assertions(1)
     const mockPingResponse = getMockUSPPingResponse()
     const mockUSPData = getMockUSPDataInUS()
@@ -230,14 +235,14 @@ describe('updateStoredPrivacyData: USP', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logDebugging).toHaveBeenCalledWith(
       'Successfully updated USP local storage data. Value:',
       mockUSPData
     )
   })
 
-  it('calls logDebugging when failing to update local storage USP data due to ping failure', () => {
+  it('calls logDebugging when failing to update local storage USP data due to ping failure', async () => {
     expect.assertions(1)
     const mockPingResponse = getMockUSPPingResponse()
     const mockUSPData = getMockUSPDataInUS()
@@ -256,13 +261,13 @@ describe('updateStoredPrivacyData: USP', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logDebugging).toHaveBeenCalledWith(
       'Could not update USP local storage data. The CMP errored.'
     )
   })
 
-  it('calls logDebugging when failing to update local storage USP data due to getUSPData failure', () => {
+  it('calls logDebugging when failing to update local storage USP data due to getUSPData failure', async () => {
     expect.assertions(1)
     const mockPingResponse = getMockUSPPingResponse()
     const mockUSPData = getMockUSPDataInUS()
@@ -281,7 +286,7 @@ describe('updateStoredPrivacyData: USP', () => {
     })
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    updateStoredPrivacyData()
+    await updateStoredPrivacyData()
     expect(logDebugging).toHaveBeenCalledWith(
       'Could not update USP local storage data. The CMP errored and provided these data:',
       mockUSPData

--- a/src/__tests__/updateStoredPrivacyData.test.js
+++ b/src/__tests__/updateStoredPrivacyData.test.js
@@ -25,6 +25,8 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
+// TODO: test behavior when CMP load times out
+
 describe('updateStoredPrivacyData: TCF', () => {
   it('does not throw if window.__tcfapi is undefined', async () => {
     expect.assertions(1)

--- a/src/__tests__/updateStoredPrivacyData.test.js
+++ b/src/__tests__/updateStoredPrivacyData.test.js
@@ -185,6 +185,64 @@ describe('updateStoredPrivacyData: USP', () => {
     )
   })
 
+  it('sets the USP ping local storage value', async () => {
+    expect.assertions(1)
+    const mockPingResponse = {
+      ...getMockUSPPingResponse(),
+      location: 'US', // in US
+    }
+    const mockUSPData = getMockUSPDataInUS()
+    window.__uspapi.mockImplementation((cmd, version, callback) => {
+      switch (cmd) {
+        case 'uspPing': {
+          callback(mockPingResponse, true)
+          break
+        }
+        case 'getUSPData': {
+          callback(mockUSPData, true)
+          break
+        }
+        default:
+      }
+    })
+    const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
+      .default
+    await updateStoredPrivacyData()
+    expect(localStorageMgr.setItem).toHaveBeenCalledWith(
+      'tabCMP.uspPing.data',
+      JSON.stringify(mockPingResponse)
+    )
+  })
+
+  it('calls logDebugging after setting the USP ping local storage value', async () => {
+    expect.assertions(1)
+    const mockPingResponse = {
+      ...getMockUSPPingResponse(),
+      location: 'US', // in US
+    }
+    const mockUSPData = getMockUSPDataInUS()
+    window.__uspapi.mockImplementation((cmd, version, callback) => {
+      switch (cmd) {
+        case 'uspPing': {
+          callback(mockPingResponse, true)
+          break
+        }
+        case 'getUSPData': {
+          callback(mockUSPData, true)
+          break
+        }
+        default:
+      }
+    })
+    const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
+      .default
+    await updateStoredPrivacyData()
+    expect(logDebugging).toHaveBeenCalledWith(
+      `Successfully updated USP ping local storage data. Value:`,
+      mockPingResponse
+    )
+  })
+
   it('sets the USP local storage value when in the US', async () => {
     expect.assertions(1)
     const mockPingResponse = {

--- a/src/__tests__/updateStoredPrivacyData.test.js
+++ b/src/__tests__/updateStoredPrivacyData.test.js
@@ -25,7 +25,36 @@ afterEach(() => {
   jest.clearAllMocks()
 })
 
-// TODO: test behavior when CMP load times out
+describe('updateStoredPrivacyData: CMP failure', () => {
+  it('does not throw if awaitCMPLoad rejects', async () => {
+    expect.assertions(1)
+    awaitCMPLoad.mockRejectedValue(new Error('Timed out.'))
+    const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
+      .default
+    await expect(updateStoredPrivacyData()).resolves.not.toThrow()
+  })
+
+  it('does not call __tcfapi or __uspapi if awaitCMPLoad rejects', async () => {
+    expect.assertions(2)
+    awaitCMPLoad.mockRejectedValue(new Error('Timed out.'))
+    const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
+      .default
+    await updateStoredPrivacyData()
+    expect(window.__tcfapi).not.toHaveBeenCalled()
+    expect(window.__uspapi).not.toHaveBeenCalled()
+  })
+
+  it('calls logDebugging if awaitCMPLoad rejects', async () => {
+    expect.assertions(1)
+    awaitCMPLoad.mockRejectedValue(new Error('Timed out.'))
+    const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
+      .default
+    await updateStoredPrivacyData()
+    expect(logDebugging).toHaveBeenCalledWith(
+      `Could not update stored privacy data.`
+    )
+  })
+})
 
 describe('updateStoredPrivacyData: TCF', () => {
   it('does not throw if window.__tcfapi is undefined', async () => {
@@ -33,9 +62,7 @@ describe('updateStoredPrivacyData: TCF', () => {
     delete window.__tcfapi
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    await expect(async () => {
-      await updateStoredPrivacyData()
-    }).not.toThrow()
+    await expect(updateStoredPrivacyData()).resolves.not.toThrow()
   })
 
   it('logs an error if window.__tcfapi is undefined', async () => {
@@ -142,9 +169,7 @@ describe('updateStoredPrivacyData: USP', () => {
     delete window.__uspapi
     const updateStoredPrivacyData = require('src/updateStoredPrivacyData')
       .default
-    await expect(async () => {
-      await updateStoredPrivacyData()
-    }).not.toThrow()
+    await expect(updateStoredPrivacyData()).resolves.not.toThrow()
   })
 
   it('logs an error if window.__uspapi is undefined', async () => {

--- a/src/awaitCMPLoad.js
+++ b/src/awaitCMPLoad.js
@@ -1,0 +1,32 @@
+import { logDebugging } from 'src/logger'
+
+// Poll for changes to the USP stub function as a
+// proxy for when the Quantcast Choice CMP has fully
+// loaded. Resolves if successful and rejects if
+// it times out.
+const awaitCMPLoad = async () => {
+  return new Promise((resolve, reject) => {
+    logDebugging(`Polling for CMP to have loaded in updateStoredPrivacyData.`)
+    const intervalMs = 500
+    let timesChecked = 0
+    const maxTimesToCheck = 20
+    const checkIfCMPLoaded = () =>
+      window.tabCMP.uspStubFunction !== window.__uspapi
+    const checker = setInterval(() => {
+      const isLoaded = checkIfCMPLoaded()
+      logDebugging(`Polling for CMP loaded. Loaded? ${isLoaded}`)
+      if (isLoaded) {
+        clearInterval(checker)
+        resolve()
+      }
+      timesChecked += 1
+      if (timesChecked > maxTimesToCheck) {
+        clearInterval(checker)
+        logDebugging(`Polling for CMP has timed out.`)
+        reject()
+      }
+    }, intervalMs)
+  })
+}
+
+export default awaitCMPLoad

--- a/src/awaitCMPLoad.js
+++ b/src/awaitCMPLoad.js
@@ -1,5 +1,7 @@
 import { logDebugging } from 'src/logger'
 
+// TODO: add tests
+
 // Poll for changes to the USP stub function as a
 // proxy for when the Quantcast Choice CMP has fully
 // loaded. Resolves if successful and rejects if

--- a/src/awaitCMPLoad.js
+++ b/src/awaitCMPLoad.js
@@ -1,7 +1,5 @@
 import { logDebugging } from 'src/logger'
 
-// TODO: add tests
-
 // Poll for changes to the USP stub function as a
 // proxy for when the Quantcast Choice CMP has fully
 // loaded. Resolves if successful and rejects if
@@ -25,7 +23,7 @@ const awaitCMPLoad = async () => {
       if (timesChecked > maxTimesToCheck) {
         clearInterval(checker)
         logDebugging(`Polling for CMP has timed out.`)
-        reject()
+        reject(new Error('Timed out while waiting for the CMP.'))
       }
     }, intervalMs)
   })

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,10 @@ export const initializeCMP = requireClientSide(async (userOptions = {}) => {
     // Set (as needed) the tab-cmp window variable. Then, set whether
     // GDPR and CCPA apply, if not set already. We use these values
     // in the modified version of the Quantcast Choice CMP JS.
+    // window.tabCMP structure:
+    //   {Boolean} doesGDPRApply
+    //   {Boolean} doesCCPAApply
+    //   {Function} uspStubFunction (set in head script)
     window.tabCMP = window.tabCMP || {}
     window.tabCMP.doesGDPRApply = Object.prototype.hasOwnProperty.call(
       window.tabCMP,

--- a/src/tagModified.html
+++ b/src/tagModified.html
@@ -80,22 +80,41 @@ try {
             return queue
           }
           // Our modified code should handle some API calls for TCF v2.
+          const cmd = args[0]
           const shouldHandle =
-            ['getTCData', 'ping', 'addEventListener'].indexOf(args[0]) > -1 &&
+            ['getTCData', 'ping', 'addEventListener', 'removeEventListener'].indexOf(cmd) > -1 &&
             args[1] === 2 &&
             typeof args[2] === 'function'
           if (shouldHandle) {
-            // This item is set and updated in tab-cmp.
-            const storedTCFData = JSON.parse(localStorage.getItem('tabCMP.tcfv2.data'))
-            if (storedTCFData) {
-              const cb = args[2]
-              logDebugging(`Responding to modified TCF API call "${args[0]}" with stored TCF data:`, storedTCFData)
-              cb(storedTCFData, true)
+            if (cmd === 'removeEventListener') {
+              // Our stubbed "addEventListener" logic doesn't add a
+              // listener, so we don't need to remove anything.
+              logDebugging(`Handled TCF API call "removeEventListener" by taking no action.`)
               return
             } else {
-              logDebugging(`No stored TCF data. Modified TCF stub is not handling a call to "${args[0]}"`)
+              // This item is set and updated in tab-cmp.
+              const storedTCFData = JSON.parse(localStorage.getItem('tabCMP.tcfv2.data'))
+              if (storedTCFData) {
+                const cb = args[2]
+                const data = {
+                  ...storedTCFData,
+                  // Google Ad Manager will consider the CMP failed if the
+                  // "addEventListener" response doesn't contain a listenerId
+                  // value, which is null in the response to "getTCData".
+                  ...(cmd === 'addEventListener' && {
+                    listenerId: 1, // a fake ID our stub won't use
+                  }) 
+                }
+                logDebugging(`Responding to modified TCF API call "${cmd}" with TCF data:`, data)
+                cb(data, true)
+                return
+              } else {
+                logDebugging(`No stored TCF data. Modified TCF stub is not handling a call to "${cmd}"`)
+              }
             }
-          } 
+          } else {
+            logDebugging(`Modified TCF stub is not handling a call to "${cmd}".`)
+          }
         } catch (e) {
           console.error('[tab-cmp]', e)
         }
@@ -205,23 +224,36 @@ try {
           return queue
         }
         // Our modified code should handle some API calls for USP v1.
+        const cmd = arg[0]
         const shouldHandle =
-          arg[0] === 'getUSPData' &&
+          ['getUSPData', 'uspPing'].indexOf(cmd) > -1 &&
           arg[1] === 1 &&
           typeof arg[2] === 'function'
         if (shouldHandle) {
-          // This item is set and updated in tab-cmp.
-          const storedUSPData = JSON.parse(localStorage.getItem('tabCMP.usp.data'))
-          if (storedUSPData) {
-            const cb = arg[2]
-            logDebugging(`Responding to modified USP API call "${arg[0]}" with stored USP data:`, storedUSPData)
-            cb(storedUSPData, true)
-            return
-          } else {
-            logDebugging(`No stored USP data. Modified USP stub is not handling a call to "${arg[0]}"`)
+          // These items are set and updated in tab-cmp.
+          if (cmd === 'getUSPData') {
+            const storedUSPData = JSON.parse(localStorage.getItem('tabCMP.usp.data'))
+            if (storedUSPData) {
+              const cb = arg[2]
+              logDebugging(`Responding to modified USP API call "${cmd}" with stored USP data:`, storedUSPData)
+              cb(storedUSPData, true)
+              return
+            } else {
+              logDebugging(`No stored USP data. Modified USP stub is not handling a call to "${cmd}"`)
+            }
+          } else if (cmd === 'uspPing') {
+            const storedUSPPingData = JSON.parse(localStorage.getItem('tabCMP.uspPing.data'))
+            if (storedUSPPingData) {
+              const cb = arg[2]
+              logDebugging(`Responding to modified USP API call "${cmd}" with stored USP ping data:`, storedUSPPingData)
+              cb(storedUSPPingData, true)
+              return
+            } else {
+              logDebugging(`No stored USP data. Modified USP stub is not handling a call to "${cmd}"`)
+            }
           }
         } else {
-          logDebugging(`Modified USP stub is not handling a call to "${arg[0]}".`)
+          logDebugging(`Modified USP stub is not handling a call to "${cmd}".`)
         }
       } catch (e) {
         console.error('[tab-cmp]', e)

--- a/src/tagModified.html
+++ b/src/tagModified.html
@@ -7,7 +7,9 @@
 try {
   (function() {
     // Gladly modified: create window object.
-    window.tabCMP = window.tabCMP || {}
+    window.tabCMP = window.tabCMP || {
+      uspStubFunction: undefined
+    }
 
     // Gladly modified: don't load the QC Choice script.
     // We'll import it ourselves.
@@ -233,6 +235,10 @@ try {
         }, 500);
       }
     };
+
+    // Gladly modified: store the stub function so we know when
+    // Quantcast Choice has finished initializing.
+    window.tabCMP.uspStubFunction = uspStubFunction
 
     var checkIfUspIsReady = function() {
       uspTries++;

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,3 +1,9 @@
+export const getMockTabCMPGlobal = () => ({
+  doesGDPRApply: false,
+  doesCCPAApply: true,
+  uspStubFunction: () => {},
+})
+
 export const getMockUSPPingResponse = () => ({
   cmpLoaded: true,
   jurisdiction: ['US'],

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,3 +1,26 @@
+/**
+ * Flush the Promise resolution queue. See:
+ * https://github.com/facebook/jest/issues/2157
+ * @return {Promise<undefined>}
+ */
+export const flushAllPromises = async () => {
+  await new Promise((resolve) => setImmediate(resolve))
+}
+
+/**
+ * Flush the Promise resolution queue, then all timers, and
+ * repeat the given number of times. This is useful for
+ * recursive async code that sets new timers.
+ * https://github.com/facebook/jest/issues/2157
+ * @return {Promise<undefined>}
+ */
+export const runAsyncTimerLoops = async (numLoops = 2) => {
+  for (let i = 0; i < numLoops; i++) {
+    await flushAllPromises()
+    jest.runAllTimers()
+  }
+}
+
 export const getMockTabCMPGlobal = () => ({
   doesGDPRApply: false,
   doesCCPAApply: true,

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -15,7 +15,8 @@ export const flushAllPromises = async () => {
  * @return {Promise<undefined>}
  */
 export const runAsyncTimerLoops = async (numLoops = 2) => {
-  for (let i = 0; i < numLoops; i++) {
+  for (let i = 0; i < numLoops; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
     await flushAllPromises()
     jest.runAllTimers()
   }

--- a/src/updateStoredPrivacyData.js
+++ b/src/updateStoredPrivacyData.js
@@ -4,6 +4,7 @@ import awaitCMPLoad from 'src/awaitCMPLoad'
 
 const TCF_LOCAL_DATA_KEY = 'tabCMP.tcfv2.data'
 const USP_LOCAL_DATA_KEY = 'tabCMP.usp.data'
+const USP_PING_LOCAL_DATA_KEY = 'tabCMP.uspPing.data'
 
 // Get the TCF and USP data from Quantcast Choice and
 // store them in local storage. This gives our stub
@@ -49,9 +50,16 @@ const updateStoredPrivacyData = async () => {
 
     // USP/CCPA
     if (typeof window.__uspapi === 'function') {
-      window.__uspapi('uspPing', 1, (_, status) => {
+      window.__uspapi('uspPing', 1, (uspPingResponse, status) => {
         if (status) {
-          // TODO: store uspPing response.
+          localStorageMgr.setItem(
+            USP_PING_LOCAL_DATA_KEY,
+            JSON.stringify(uspPingResponse)
+          )
+          logDebugging(
+            `Successfully updated USP ping local storage data. Value:`,
+            uspPingResponse
+          )
 
           window.__uspapi('getUSPData', 1, (uspData, success) => {
             if (success && uspData) {

--- a/src/updateStoredPrivacyData.js
+++ b/src/updateStoredPrivacyData.js
@@ -4,18 +4,54 @@ import { logDebugging, logError } from 'src/logger'
 const TCF_LOCAL_DATA_KEY = 'tabCMP.tcfv2.data'
 const USP_LOCAL_DATA_KEY = 'tabCMP.usp.data'
 
+// A proxy for when the Quantcast Choice CMP has fully
+// loaded. Resolves if successful and rejects if
+// it times out.
+const waitForCMPToReplaceAPIStubs = async () => {
+  return new Promise((resolve, reject) => {
+    logDebugging(`Polling for CMP to have loaded in updateStoredPrivacyData.`)
+    const intervalMs = 500
+    let timesChecked = 0
+    const maxTimesToCheck = 20
+    const checkIfCMPLoaded = () =>
+      window.tabCMP.uspStubFunction !== window.__uspapi
+    const checker = setInterval(() => {
+      const isLoaded = checkIfCMPLoaded()
+      logDebugging(`Polling for CMP loaded. Loaded? ${isLoaded}`)
+      if (isLoaded) {
+        clearInterval(checker)
+        resolve()
+      }
+      timesChecked += 1
+      if (timesChecked > maxTimesToCheck) {
+        clearInterval(checker)
+        logDebugging(`Polling for CMP has timed out.`)
+        reject()
+      }
+    }, intervalMs)
+  })
+}
+
 // Get the TCF and USP data from Quantcast Choice and
 // store them in local storage. This gives our stub
 // functions quicker access to the user's choices.
-const updateStoredPrivacyData = () => {
+const updateStoredPrivacyData = async () => {
+  // It's critical Quantcast Choice is loaded, replacing our
+  // modified stub functions, before we sync.
+  // Otherwise, we'd be receiving our own local storage data
+  // when trying to update local storage data.
+  try {
+    await waitForCMPToReplaceAPIStubs()
+  } catch (e) {
+    logDebugging(`Could not update stored privacy data.`)
+    return
+  }
+
   try {
     logDebugging(`Syncing local storage TCF and USP data.`)
 
     // TCF/GDPR
     if (typeof window.__tcfapi === 'function') {
-      // It's critical Quantcast Choice is loaded before we sync.
-      // Otherwise, we'd be receiving our own local storage data
-      // when trying to update local storage data.
       window.__tcfapi('getTCData', 2, (tcData, success) => {
         if (success && tcData) {
           localStorageMgr.setItem(TCF_LOCAL_DATA_KEY, JSON.stringify(tcData))
@@ -40,12 +76,10 @@ const updateStoredPrivacyData = () => {
 
     // USP/CCPA
     if (typeof window.__uspapi === 'function') {
-      // The ping ensures Quantcast Choice is loaded before we sync
-      // USP data. It's important our modified USP stub does not
-      // handle uspPing; otherwise, we'd be receiving our own local
-      // storage data when trying to update local storage data.
       window.__uspapi('uspPing', 1, (_, status) => {
         if (status) {
+          // TODO: store uspPing response.
+
           window.__uspapi('getUSPData', 1, (uspData, success) => {
             if (success && uspData) {
               localStorageMgr.setItem(


### PR DESCRIPTION
* Use a modified stub to handle the USP "uspPing" command
* Store the head script's USP stub function in the `tabCMP` window object so our code can poll to know that the CMP has loaded (when it has replaced the stub function)
* Add a `listenerId` to the TCF data when called with "addEventListener"
